### PR TITLE
Fixed shell script error

### DIFF
--- a/SSH/SSHCommand.sh
+++ b/SSH/SSHCommand.sh
@@ -22,10 +22,10 @@ puts "password: "
 set password $expect_out(1,string)
 
 set arguments "[lindex $argv 0] -v"
-set path $argv0
+set path [ exec dirname $argv0 ];
 
 #kill previous command
-exec $path/../KillTunnel.sh $arguments
+exec $path/KillTunnel.sh $arguments
 
 eval spawn $arguments
 


### PR DESCRIPTION
After compiling on MacOS 10.13 i got error "SSHCommand.sh is not a directory". I found the shell script use next construction which is not work on 10.13: "/path/SSHCommand.sh/../KillTunnel.sh"